### PR TITLE
Add cabal file and stack.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ corpus/
 *.hi
 *.o
 markovpass
+.stack-work

--- a/markovpass.cabal
+++ b/markovpass.cabal
@@ -1,0 +1,13 @@
+Name:          markovpass
+Version:       0.1.0.0
+Build-type:    Simple
+Cabal-version: >=1.10
+
+Library
+  Exposed-modules:  Data.Markov
+                  , Data.Markov.Passphrase
+  Default-language: Haskell2010
+  Build-depends:    base >= 4.7 && < 5
+                  , MonadRandom
+                  , split
+                  , containers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-5.16
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []


### PR DESCRIPTION
Adding both the cabal file and the stack.yaml file, to make it easier for people to build your project.

A lot of people choose not to keep the stack.yaml file in their repos, since it can be easily generated using `stack init`, but I put it here just to make it easier for you to get started. 

I use `stack build --file-watch` to start an instance of stack, which compiles the library and then re-compiles the library every time you change any file.

Let me know if you have any questions!